### PR TITLE
Added link to the slackin icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ docker pull mhart/alpine-node:latest
 * During workshop the following ports are used: `80`, `8088` and the range `4000-4010`. If they are not available on your machine, adjust the CLI commands accordingly.
 
 ### Chat
-![Members online on Docker Barcelona Slack](https://dockerbcn.herokuapp.com/badge.svg)
+[![Members online on Docker Barcelona Slack](https://dockerbcn.herokuapp.com/badge.svg)](https://dockerbcn.herokuapp.com)
 
 Join [Docker Barcelona Slack](https://dockerbcn.herokuapp.com)! 
 


### PR DESCRIPTION
Slackin icon was redirecting to the icon itself. Now it redirects to slackin as the linked text below it.
