### PR TITLE
Fix node crash (server is not defined)

### DIFF
--- a/code/guestbook-node/main.js
+++ b/code/guestbook-node/main.js
@@ -41,7 +41,7 @@ client.on("error", function (err) {
 
 process.on("SIGTERM", function () {
     client.quit();
-    server.close(function () {
+    app.close(function () {
         process.exit(0);
     });
 });


### PR DESCRIPTION
Probably a copy-paste error. The express server variable is called `app'.